### PR TITLE
added support for resizable circle image

### DIFF
--- a/Classes/APAvatarImageView.m
+++ b/Classes/APAvatarImageView.m
@@ -8,19 +8,13 @@
 
 #import "APAvatarImageView.h"
 
-@interface APAvatarImageView ()
-
-- (void)draw;
-
-@end
-
 @implementation APAvatarImageView
 
 - (id)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (self) {
-        _cornerRadius = self.frame.size.height/2.0f;
+        _isCircle = YES;
         [self draw];
     }
     return self;
@@ -31,7 +25,7 @@
     self = [super initWithCoder:aDecoder];
     if (self) {
         _borderWidth = -1.0;
-        _cornerRadius = self.frame.size.height/2.0f;
+        _isCircle = YES;
         [self draw];
     }
     return self;
@@ -39,26 +33,12 @@
 
 - (id)initWithFrame:(CGRect)frame borderColor:(UIColor*)borderColor borderWidth:(float)borderWidth
 {
-    self = [super initWithFrame:frame];
-    if (self) {
-        _borderColor = borderColor;
-        _borderWidth = borderWidth;
-        _cornerRadius = self.frame.size.height/2.0f;
-        [self draw];
-    }
-    return self;
+    return [self initWithImage:nil highlightedImage:nil borderColor:borderColor borderWidth:borderWidth];
 }
 
 - (id)initWithImage:(UIImage *)image borderColor:(UIColor*)borderColor borderWidth:(float)borderWidth
 {
-    self = [super initWithImage:image];
-    if (self) {
-        _borderColor = borderColor;
-        _borderWidth = borderWidth;
-        _cornerRadius = self.frame.size.height/2.0f;
-        [self draw];
-    }
-    return self;
+    return [self initWithImage:image highlightedImage:nil borderColor:borderColor borderWidth:borderWidth];
 }
 
 - (id)initWithImage:(UIImage *)image highlightedImage:(UIImage *)highlightedImage borderColor:(UIColor*)borderColor borderWidth:(float)borderWidth
@@ -67,7 +47,7 @@
     if (self) {
         _borderColor = borderColor;
         _borderWidth = borderWidth;
-        _cornerRadius = self.frame.size.height/2.0f;
+        _isCircle = YES;
         [self draw];
     }
     return self;
@@ -88,6 +68,12 @@
 -(void)setCornerRadius:(float)cornerRadius
 {
     _cornerRadius = cornerRadius;
+    _isCircle = NO;
+    [self draw];
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
     [self draw];
 }
 
@@ -99,7 +85,7 @@
     }
     CALayer *l = [self layer];
     [l setMasksToBounds:YES];
-    [l setCornerRadius:_cornerRadius];
+    l.cornerRadius = _isCircle ? (self.frame.size.height/2.0) : _cornerRadius;
     if (_borderWidth < 0) { // Default case
         [l setBorderWidth:3.0];
     } else {


### PR DESCRIPTION
When using constraints the size of the avatar image can change. This pull request keeps the avatar image as a circle when desired.

Specifically this is an issue when adding support for the different screen sizes with iPhone 6+
