### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ avatarImageView.borderWidth = 3.0;
 
 ## Demo
 
-There is a Demo XCode project in the Demo folder. Just clone the repository and run `pod install` and finally run the project by opening the Avatar.xcworkspace
+There is a Demo Xcode project in the Demo folder. Just clone the repository and run `pod install` and finally run the project by opening the Avatar.xcworkspace
 
 ## License
 


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
